### PR TITLE
Fix bug in Dynamic coder when handling UUIDs

### DIFF
--- a/lib/fdb/coder/dynamic.ex
+++ b/lib/fdb/coder/dynamic.ex
@@ -82,8 +82,10 @@ defmodule FDB.Coder.Dynamic do
   defp do_decode(<<0x21>> <> _rest = full, coders, acc),
     do: apply_coder(:float64, full, coders, acc)
 
-  defp do_decode(<<0x30>> <> _rest = full, coders, acc),
-    do: apply_coder(:uuid, full, coders, acc)
+  defp do_decode(<<0x30>> <> _rest = full, coders, acc) do
+    {value, rest} = coders[:uuid].module.decode(full, coders[:uuid].opts)
+    {Tuple.append(acc, {:uuid, value <> rest}), ""}
+  end
 
   defp do_decode(<<0x33>> <> _rest = full, coders, acc),
     do: apply_coder(:versionstamp, full, coders, acc)


### PR DESCRIPTION
Howdy,

I've fixed an issue where the Dynamic coder fails to decode a UUID.

**Example**
```elixir
uuid = <<0x30>> <> UUID.uuid4()
FDB.Coder.Dynamic.decode(uuid, [uuid: FDB.Coder.UUID.new()])
```

**Exception**
```shell
** (FunctionClauseError) no function clause matching in FDB.Coder.Dynamic.do_decode/3

    The following arguments were given to FDB.Coder.Dynamic.do_decode/3:

        # 1
        "ab-955b-5119d1abf4dc"

        # 2
        [uuid: %FDB.Coder{module: FDB.Coder.UUID, opts: nil}]

        # 3
        {{:uuid, "2f39c310-3ab4-4d"}}

    Attempted function clauses (showing 10 out of 11):

        defp do_decode(<<0::integer(), rest::binary()>>, _coders, acc)
        defp do_decode(<<1::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<2::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<32::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<33::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<48::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<51::integer(), _rest::binary()>> = full, coders, acc)
        defp do_decode(<<5::integer(), rest::binary()>>, coders, acc)
        defp do_decode(<<x::integer()-size(8), _rest::binary()>> = full, coders, acc) when is_integer(x) and (x >= 12 and x <= 28)
        defp do_decode(<<x::integer()-size(8), _rest::binary()>> = full, coders, acc) when x === 38 or x === 39
```

The issue seems to stem from the UUID tuple not being handled correctly in the `do_decode/3` function for UUID. I believe this was missed by the tests because the stream data module doesn't explicitly generate UUIDs so the magic byte `<<0x30>>` isn't ever hit. I'm not quite sure how to setup a custom generator yet or I'll add one and a spec for this specific case.

This seems to fix my issue, if you have any suggestions or would prefer I change something about the PR let me know...

Best,
Seve

P.S.
Thanks for all your hard work on this package!